### PR TITLE
Feature/029：チャット機能更新、layoutsを使っての画面共用化など

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use App\Models\Chat_room as chatroom; 
+use App\Models\Message;
 
 class HomeController extends Controller
 {
@@ -24,5 +26,18 @@ class HomeController extends Controller
     public function index()
     {
         return view('home');
+    }
+    public function studentChat($tid,$id)
+    {
+        $login_user=1;
+        if ($login_user !== $id){
+            return redirect("/student/home");
+        }
+        $chatroom = chatroom::where('teacher_id', $tid)->where('student_id', $id)->first();
+        $message = Message::where('chat_room_id', $chatroom->id)->get();
+        return view('student.chat', [
+            'chatroom' => $chatroom,
+            'message' => $message,
+        ]);
     }
 }

--- a/app/Http/Controllers/MessageController.php
+++ b/app/Http/Controllers/MessageController.php
@@ -7,22 +7,37 @@ use App\Models\Message;
 
 class MessageController extends Controller
 {
-    public function chat(Request $request)
+    public function t_chat(Request $request)
+    {
+        // $request->session()->put('chat_room_id', 1);
+        $chat_room_id=1;
+        $login_user_id=1;
+        return view('teacher.chat', compact('chat_room_id','login_user_id'));
+
+        // TODO:過去投稿分を再表示させる
+        $messages = Message::orderBy('created_at', 'asc')->get();
+        return view('teacher.chat', [
+            'body' => $messages,
+        ]);
+    }
+
+    public function s_chat(Request $request)
     {
         // $request->session()->put('chat_room_id', 1);
         $chat_room_id=2;
         $login_user_id=2;
-        return view('chat',[
-            'chat_room_id' => $chat_room_id,
-            'login_user_id' => $login_user_id,
-        ]);
+        return view('student.chat', compact('chat_room_id','login_user_id'));
 
+        // TODO:過去投稿分を再表示させる
+        $messages = Message::orderBy('created_at', 'asc')->get();
+        return view('student.chat', [
+            'body' => $messages,
+        ]);
     }
+
     // ここでチャット内容を保存
     public function chat2(Request $request)
     {
-
-
         $message = new Message();
         $message->body=$request->msg;
         $message->chat_room_id=$request->cid;
@@ -33,8 +48,8 @@ class MessageController extends Controller
             [
                 'body' => $request->msg,
                 'chat_room_id' => $request->cid,
-                'create_user_id' => $request->lid
+                'create_user_id' => $request->lid,
+                'created_at' => $message->created_at
             ]);
-
     }
 }

--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -1,8 +1,21 @@
 $(function () {
 
+    // XSS対策(サニタイジング：エスケープ処理)
+    function escapeHTML(string){
+        return string.replace(/&/g, '&lt;')
+        .replace(/</g, '&lt')
+        .replace(/>/g, '&gt')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#x27;');
+    }
+
     // クラスではなくIDでしたので修正しました
     $('#submit-button').click(function () {
         var message = $('#msg').val()
+        if(message == false){
+            alert ("メッセージを入力してください。");
+            return false;
+        }
         var chat_room_id = $('#chat_room_id').val()
         var login_user_id = $('#login_user_id').val()
         $.ajax({
@@ -24,6 +37,23 @@ $(function () {
                 .done(function(data){
             // アラートは削除するの手間なのでログで確認しました。
 
+            // 投稿日時を表示
+            let toDoubleDigits = function(num) {
+                num += "";
+                if (num.length === 1) {
+                    num = "0" + num;
+                }
+                return num;
+            };
+                let d = new Date(data.created_at);
+                let year = d.getFullYear();
+                let month = toDoubleDigits(d.getMonth() + 1);
+                let day = toDoubleDigits(d.getDate());
+                let hour = toDoubleDigits(d.getHours());
+                let minute = toDoubleDigits(d.getMinutes());
+                let second = toDoubleDigits(d.getSeconds());
+                let created_date = year + '-' + month + '-' + day + ' ' + hour + ':' + minute + ':' + second;
+
                     var html = `
                         <div class="media comment-visible">
                             <div class="media-body comment-body">
@@ -31,9 +61,9 @@ $(function () {
                                     <div class="flex-row">
                                         <span class="comment-body-user" id="user_name">田中学</span>
                                         <span>　</span>
-                                        <span class="comment-body-user small" id="created_at">05-05 12:00</span>
+                                        <span class="comment-body-user small" id="created_at">${created_date}</span>
                                     </div>
-                                    <span class="comment-body-user pb-3" id="body">${data.body}</span>
+                                    <span class="comment-body-user pb-3" id="body">${escapeHTML(data.body)}</span>
                                 </div>
                             </div>
                         </div>

--- a/resources/views/layouts/student.blade.php
+++ b/resources/views/layouts/student.blade.php
@@ -1,0 +1,73 @@
+<!doctype html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <!-- CSRF Token -->
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+
+    <title>{{ config('app.name', 'Laravel') }}</title>
+
+    <!-- Scripts -->
+    <script src="{{ asset('js/app.js') }}" defer></script>
+
+    <!-- Fonts -->
+    <link rel="dns-prefetch" href="//fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css?family=Nunito" rel="stylesheet">
+
+    <!-- Styles -->
+    <link href="{{ asset('css/app.css') }}" rel="stylesheet">
+</head>
+<body>
+    <div id="app">
+    <header>
+            <nav class="navbar navbar-expand-md navbar-light bg-white shadow-sm">
+                <div class="container">
+                    <a class="navbar-brand" href="{{ url('/student/home') }}">
+                        {{ __('東京小学校　体調管理システム') }}
+                    </a>
+                    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="{{ __('Toggle navigation') }}">
+                        <span class="navbar-toggler-icon"></span>
+                    </button>
+
+                    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+                        <!-- Left Side Of Navbar -->
+                        <ul class="navbar-nav me-auto">
+
+                        </ul>
+
+                        <!-- Right Side Of Navbar -->
+                        <ul class="navbar-nav ms-auto">
+                            <!-- Authentication Links -->
+                            <!-- @guest
+                            @if (Route::has('login')) -->
+                            <li class="nav-item">
+                                <a class="nav-link" href="{{ url('/student/notification') }}">{{ __('先生からのお知らせ') }}</a>
+                            </li>
+
+                            <li class="nav-item">
+                                <a class="nav-link" href="{{ url('/student/edit') }}">{{ __('アカウント編集') }}</a>
+                            </li>
+                            <!-- @endif -->
+                            <li class="nav-item">
+                                <a class="nav-link" href="{{ route('logout') }}" onclick="event.preventDefault(); document.getElementById('logout-form').submit();">
+                                    {{ __('ログアウト') }}
+                                </a>
+
+                                <form id="logout-form" action="{{ route('logout') }}" method="POST" class="d-none">
+                                    @csrf
+                                </form>
+                            </li>
+                            @endguest
+                        </ul>
+                    </div>
+                </div>
+            </nav>
+        </header>
+
+        @yield('content')
+
+    </div>
+</body>
+</html>

--- a/resources/views/layouts/teacher.blade.php
+++ b/resources/views/layouts/teacher.blade.php
@@ -1,0 +1,69 @@
+<!doctype html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <!-- CSRF Token -->
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+
+    <title>{{ config('app.name', 'Laravel') }}</title>
+
+    <!-- Scripts -->
+    <script src="{{ asset('js/app.js') }}" defer></script>
+
+    <!-- Fonts -->
+    <link rel="dns-prefetch" href="//fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css?family=Nunito" rel="stylesheet">
+
+    <!-- Styles -->
+    <link href="{{ asset('css/app.css') }}" rel="stylesheet">
+</head>
+<body>
+    <div id="app">
+        <header>
+            <nav class="navbar navbar-expand-md navbar-light bg-white shadow-sm">
+                <div class="container">
+                    <a class="navbar-brand" href="{{ url('/teacher/home') }}">
+                        {{ __('東京小学校　体調管理システム') }}
+                    </a>
+                    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="{{ __('Toggle navigation') }}">
+                        <span class="navbar-toggler-icon"></span>
+                    </button>
+
+                    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+                        <!-- Left Side Of Navbar -->
+                        <ul class="navbar-nav me-auto">
+
+                        </ul>
+
+                        <!-- Right Side Of Navbar -->
+                        <ul class="navbar-nav ms-auto">
+                            <!-- Authentication Links -->
+                            <!-- @guest
+                                @if (Route::has('login')) -->
+                                    <li class="nav-item">
+                                        <a class="nav-link" href="{{ url('/teacher/edit') }}">{{ __('アカウント作成／編集') }}</a>
+                                    </li>
+                                <!-- @endif -->
+                                <li class="nav-item">
+                                        <a class="nav-link" href="{{ route('logout') }}" onclick="event.preventDefault(); document.getElementById('logout-form').submit();">
+                                            {{ __('ログアウト') }}
+                                        </a>
+
+                                        <form id="logout-form" action="{{ route('logout') }}" method="POST" class="d-none">
+                                            @csrf
+                                        </form>
+                                </li>
+                            @endguest
+                        </ul>
+                    </div>
+                </div>
+            </nav>
+        </header>
+
+        @yield('content')
+
+    </div>
+</body>
+</html>

--- a/resources/views/student/chat.blade.php
+++ b/resources/views/student/chat.blade.php
@@ -50,24 +50,27 @@
         <div class="chat-area">
             <div class="card">
                 <div class="card-header">チャット部屋</div>
-                <div class="card-body chat-card">
-                    <div id="test"></div>
+                    <div class="card-body chat-card">
+                        <div id="test"></div>
+                    </div>
                 </div>
             </div>
         </div>
-    </div>
 
-    <div class="comment-container row justify-content-center">
-        <div class="input-group comment-area">
-            <textarea id="msg" class="form-control" placeholder="ここにメッセージを入力(最大250文字まで)" maxlength="250" aria-label="With textarea"></textarea>
-            <button id="submit-button" type="input-group-prepend button" class="btn btn-outline-primary comment-btn">投稿する</button>
+        <div class="comment-container row justify-content-center">
+            <div class="input-group comment-area">
+                <input type="hidden" id="chat_room_id" value="{{ $chat_room_id }}">
+                <input type="hidden" id="login_user_id" value="{{ $login_user_id }}">
+                <textarea id="msg" class="form-control" placeholder="ここにメッセージを入力(最大250文字まで)" maxlength="250" aria-label="With textarea"></textarea>
+                <button id="submit-button" type="input-group-prepend button" class="btn btn-outline-primary comment-btn">投稿する</button>
+            </div>
         </div>
+
+        @endsection
+
+        @section('js')
+        <script src="{{ asset('js/chat.js') }}"></script>
+
+        @endsection
     </div>
-
-    @endsection
-
-    @section('js')
-    <script src="{{ asset('js/chat.js') }}"></script>
-
-    @endsection
 </div>

--- a/resources/views/student/home.blade.php
+++ b/resources/views/student/home.blade.php
@@ -1,56 +1,10 @@
 <!-- 4.生徒用ホーム画面 -->
 
-@extends('layouts.app')
+@extends('layouts.student')
 
 @section('content')
-<form method="POST" action="{{ url('/student/home') }}">
-    @csrf
-<div id="app">
-        <nav class="navbar navbar-expand-md navbar-light bg-white shadow-sm">
-            <div class="container">
-                <a class="navbar-brand" href="{{ url('/student/home') }}">
-                    {{ __('東京小学校　体調管理システム') }}
-                </a>
-                <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="{{ __('Toggle navigation') }}">
-                    <span class="navbar-toggler-icon"></span>
-                </button>
 
-                <div class="collapse navbar-collapse" id="navbarSupportedContent">
-                    <!-- Left Side Of Navbar -->
-                    <ul class="navbar-nav me-auto">
-
-                    </ul>
-
-                    <!-- Right Side Of Navbar -->
-                    <ul class="navbar-nav ms-auto">
-                        <!-- Authentication Links -->
-                        <!-- @guest
-                            @if (Route::has('login')) -->
-                            <li class="nav-item">
-                                    <a class="nav-link" href="{{ url('/student/notification') }}">{{ __('先生からのお知らせ') }}</a>
-                                </li>
-
-                                <li class="nav-item">
-                                    <a class="nav-link" href="{{ url('/student/edit') }}">{{ __('アカウント編集') }}</a>
-                                </li>
-                            <!-- @endif -->
-                            <li class="nav-item">
-                                    <a class="nav-link" href="{{ route('logout') }}" onclick="event.preventDefault(); document.getElementById('logout-form').submit();">
-                                        {{ __('ログアウト') }}
-                                    </a>
-
-                                    <form id="logout-form" action="{{ route('logout') }}" method="POST" class="d-none">
-                                        @csrf
-                                    </form>
-                            </li>
-                        @endguest
-                    </ul>
-                </div>
-            </div>
-        </nav>
-    </div>
-
-    <div style="display: block; text-align: center; margin-bottom: 20px;">
+    <div style="display: block; text-align: center; margin: 20px 0 20px 0;">
     <?php
         date_default_timezone_set('Asia/Tokyo');
         function funcWeek(){
@@ -64,11 +18,17 @@
     </div>
 
     <!-- 前日に報告がない場合のみ表示するように実装予定 -->
-    <div class="text-center mb-5 bg-warning">
-        <h3>前日の体調報告がありません。</br>体調報告画面より報告してください。</h3>
+    <div class="container">
+        <div class="row justify-content-center">
+            <div class="col-md-8">
+                <div class="text-center bg-warning rounded-3 py-1 h3">
+                    前日の体調報告がありません。</br>体調報告画面より報告してください。
+                </div>
+            </div>
+        </div>
     </div>
 
-    <div class="d-grid gap-5 col-4 mx-auto">
+    <div class="d-grid gap-5 col-4 mx-auto py-4">
         <button type="submit" class="btn btn-primary" onclick="location.href='report'">
             {{ __('体調報告画面') }}
         </button>
@@ -76,4 +36,4 @@
             {{ __('先生とチャット') }}
         </button>
     </div>
-</div>
+@endsection 

--- a/resources/views/student/list.blade.php
+++ b/resources/views/student/list.blade.php
@@ -43,15 +43,16 @@
         <!-- 下記波括弧部分(姓～メールアドレス)については、レコードから情報を取得できるようにすること -->
         <tr>
             <td>{{ '佐藤先生' }}</td>
-            <td style="text-align: center;"><a href="{{ url('/student/chat') }}">{{ 'チャット画面へ' }}</a></td>
+            <!-- TODO:リンク先の後ろにユーザーIDを取得させる(今は固定値で1が入っている)-->
+            <td style="text-align: center;"><a href="{{ url('/student/chat/t1') }}/1">{{ 'チャット画面へ' }}</a></td>
         </tr>
         <tr>
             <td>{{ '西尾先生' }}</td>
-            <td style="text-align: center;"><a href="{{ url('/student/chat') }}">{{ 'チャット画面へ' }}</a></td>
+            <td style="text-align: center;"><a href="{{ url('/student/chat/t2') }}">{{ 'チャット画面へ' }}</a></td>
         </tr>
         <tr>
             <td>{{ '近藤先生' }}</td>
-            <td style="text-align: center;"><a href="{{ url('/student/chat') }}">{{ 'チャット画面へ' }}</a></td>
+            <td style="text-align: center;"><a href="{{ url('/student/chat/t3') }}">{{ 'チャット画面へ' }}</a></td>
         </tr>
     </table>
 

--- a/resources/views/student/manage.blade.php
+++ b/resources/views/student/manage.blade.php
@@ -34,10 +34,10 @@
                             <label for="name">昨日は何回食事をとりましたか？</label></br>
                             <input type="text" name="day" size = "30">
                         </div>
-                            <button type="submit">報告する</button>
                     </form>
-                    <a href=""><button type="button">キャンセル</button></a>
-                    <a href=""><button type="button">過去に報告した内容を</br>確認/編集する</button></a>
+                    <button type="submit" class="btn btn-primary my-3">報告する</button>
+                    <a href="{{ url('/student/home') }}"><button type="button" class="btn btn-secondary">キャンセル</button></a>
+                    <a href="{{ url('/student/newslist') }}"><button type="button" class="btn btn-secondary my-2">過去に報告した内容を</br>確認/編集する</button></a>
                 </div>
             </div>
         </div>

--- a/resources/views/student/newslist.blade.php
+++ b/resources/views/student/newslist.blade.php
@@ -1,18 +1,21 @@
 <!-- 8-2 生徒用報告情報編集/削除 選択画面 -->
 
-@extends('layouts.app')
+@extends('layouts.student')
 
 @section('content')
 <div class="container">
     <div class="row justify-content-center">
         <div class="col-md-10">
-            <div class="card">
-            <div class="card-header">{{ __('東京小学校　体調管理システム') }}</div>
+            <div class="card my-4">
                 <div class="card-body">
                     <form method="POST" action="{{ url('/student/login') }}">
                         @csrf
-                        <a href=""><button type="button">ホーム画面に戻る</button></a>
-                        <div style="border: #808000 solid 1px; font-size: 100%; padding: 3px; background-color:#87CEFA;">先生からのお知らせ一覧画面です。</div>
+                        <div class="gap-5 col-4 mx-3 py-4">
+                            <a href="/teacher/home" class="btn btn-primary">
+                                {{ __('ホーム画面へ戻る') }}
+                            </a>
+                        </div>
+                        <div style="border: #808000 solid 1px; font-size: 100%; padding: 3px; background-color:#87CEFA;" class="my-4">先生からのお知らせ一覧画面です。</div>
                         <div>
                             <table class="table table-striped table-bordered">
                             <thead>
@@ -26,52 +29,52 @@
                                 <tr>
                                     <td>2022/1/10</td>
                                     <td>あけましておめでとうございます。本年もよろしくお願い致します。</td>
-                                    <td><button>全文を見る</button></td>
+                                    <td style="text-align: center;"><a href="{{ url('/student/notification') }}">{{ '全文を見る' }}</a></td>
                                 </tr>
                                 <tr>
                                     <td>2022/5/2</td>
                                     <td>普通</td>
-                                    <td><button>全文を見る</button></td>
+                                    <td style="text-align: center;"><a href="{{ url('/student/notification') }}">{{ '全文を見る' }}</a></td>
                                 </tr>
                                 <tr>
                                     <td></td>
                                     <td></td>
-                                    <td><button>全文を見る</button></td>
+                                    <td style="text-align: center;"><a href="{{ url('/student/notification') }}">{{ '全文を見る' }}</a></td>
                                 </tr>
                                 <tr>
                                     <td></td>
                                     <td></td>
-                                    <td><button>全文を見る</button></td>
+                                    <td style="text-align: center;"><a href="{{ url('/student/notification') }}">{{ '全文を見る' }}</a></td>
                                 </tr>
                                 <tr>
                                     <td></td>
                                     <td></td>
-                                    <td><button>全文を見る</button></td>
+                                    <td style="text-align: center;"><a href="{{ url('/student/notification') }}">{{ '全文を見る' }}</a></td>
                                 </tr>
                                 <tr>
                                     <td></td>
                                     <td></td>
-                                    <td><button>全文を見る</button></td>
+                                    <td style="text-align: center;"><a href="{{ url('/student/notification') }}">{{ '全文を見る' }}</a></td>
                                 </tr>
                                 <tr>
                                     <td></td>
                                     <td></td>
-                                    <td><button>全文を見る</button></td>
+                                    <td style="text-align: center;"><a href="{{ url('/student/notification') }}">{{ '全文を見る' }}</a></td>
                                 </tr>
                                 <tr>
                                     <td></td>
                                     <td></td>
-                                    <td><button>全文を見る</button></td>
+                                    <td style="text-align: center;"><a href="{{ url('/student/notification') }}">{{ '全文を見る' }}</a></td>
                                 </tr>
                                 <tr>
                                     <td></td>
                                     <td></td>
-                                    <td><button>全文を見る</button></td>
+                                    <td style="text-align: center;"><a href="{{ url('/student/notification') }}">{{ '全文を見る' }}</a></td>
                                 </tr>
                                 <tr>
                                     <td></td>
                                     <td></td>
-                                    <td><button>全文を見る</button></td>
+                                    <td style="text-align: center;"><a href="{{ url('/student/notification') }}">{{ '全文を見る' }}</a></td>
                                 </tr>
                             </tbody>
                             </table>

--- a/resources/views/teacher/account.blade.php
+++ b/resources/views/teacher/account.blade.php
@@ -1,53 +1,9 @@
 <!-- 6-1.アカウント作成／編集画面(先生用) -->
 
-@extends('layouts.app')
+@extends('layouts.teacher')
 
 @section('content')
-<form method="POST" action="{{ url('/teacher/account') }}">
-    @csrf
-<div id="app">
-        <nav class="navbar navbar-expand-md navbar-light bg-white shadow-sm">
-            <div class="container">
-                <a class="navbar-brand" href="{{ url('/teacher/home') }}">
-                    {{ __('東京小学校　体調管理システム') }}
-                </a>
-                <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="{{ __('Toggle navigation') }}">
-                    <span class="navbar-toggler-icon"></span>
-                </button>
-
-                <div class="collapse navbar-collapse" id="navbarSupportedContent">
-                    <!-- Left Side Of Navbar -->
-                    <ul class="navbar-nav me-auto">
-
-                    </ul>
-
-                    <!-- Right Side Of Navbar -->
-                    <ul class="navbar-nav ms-auto">
-                        <!-- Authentication Links -->
-                        <!-- @guest
-                            @if (Route::has('login')) -->
-                            <!-- @endif -->
-                            <li class="nav-item">
-                                    <a class="nav-link" href="{{ route('logout') }}" onclick="event.preventDefault(); document.getElementById('logout-form').submit();">
-                                        {{ __('ログアウト') }}
-                                    </a>
-
-                                    <form id="logout-form" action="{{ route('logout') }}" method="POST" class="d-none">
-                                        @csrf
-                                    </form>
-                            </li>
-                        @endguest
-                    </ul>
-                </div>
-            </div>
-        </nav>
-
-        <main class="py-4">
-            @yield('content')
-        </main>
-    </div>
-
-    <div class="d-grid gap-5 col-4 mx-auto">
+    <div class="d-grid gap-5 col-4 mx-auto py-5">
         <button type="submit" class="btn btn-primary" onclick="location.href='registerforstudent'">
             {{ __('生徒用アカウント作成') }}
         </button>
@@ -55,4 +11,4 @@
             {{ __('自分のアカウント編集') }}
         </button>
     </div>
-</div>
+@endsection

--- a/resources/views/teacher/chat.blade.php
+++ b/resources/views/teacher/chat.blade.php
@@ -66,7 +66,7 @@
             <div class="input-group comment-area">
                 <input type="hidden" id="chat_room_id" value="{{ $chat_room_id }}">
                 <input type="hidden" id="login_user_id" value="{{ $login_user_id }}">
-                <textarea id="msg" required class="form-control" placeholder="ここにメッセージを入力(最大250文字まで)" maxlength="250" aria-label="With textarea"></textarea>
+                <textarea id="msg" class="form-control" placeholder="ここにメッセージを入力(最大250文字まで)" maxlength="250" aria-label="With textarea"></textarea>
                 <button id="submit-button" type="input-group-prepend button" class="btn btn-outline-primary comment-btn">投稿する</button>
             </div>
         </div>

--- a/resources/views/teacher/home.blade.php
+++ b/resources/views/teacher/home.blade.php
@@ -1,64 +1,14 @@
 <!-- 4.先生用ホーム画面 -->
 
-@extends('layouts.app')
+@extends('layouts.teacher')
 
 @section('content')
-<form method="POST" action="{{ url('/teacher/home') }}">
-    @csrf
-<div id="app">
-        <nav class="navbar navbar-expand-md navbar-light bg-white shadow-sm">
-            <div class="container">
-                <a class="navbar-brand" href="{{ url('/teacher/home') }}">
-                    {{ __('東京小学校　体調管理システム') }}
-                </a>
-                <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="{{ __('Toggle navigation') }}">
-                    <span class="navbar-toggler-icon"></span>
-                </button>
-
-                <div class="collapse navbar-collapse" id="navbarSupportedContent">
-                    <!-- Left Side Of Navbar -->
-                    <ul class="navbar-nav me-auto">
-
-                    </ul>
-
-                    <!-- Right Side Of Navbar -->
-                    <ul class="navbar-nav ms-auto">
-                        <!-- Authentication Links -->
-                        <!-- @guest
-                            @if (Route::has('login')) -->
-                                <li class="nav-item">
-                                    <a class="nav-link" href="{{ url('/teacher/account') }}">{{ __('アカウント作成／編集') }}</a>
-                                </li>
-                            <!-- @endif -->
-                            <li class="nav-item">
-                                    <a class="nav-link" href="{{ route('logout') }}" onclick="event.preventDefault(); document.getElementById('logout-form').submit();">
-                                        {{ __('ログアウト') }}
-                                    </a>
-
-                                    <form id="logout-form" action="{{ route('logout') }}" method="POST" class="d-none">
-                                        @csrf
-                                    </form>
-                            </li>
-                        @endguest
-                    </ul>
-                </div>
-            </div>
-        </nav>
-
-        <main class="py-4">
-            @yield('content')
-        </main>
-    </div>
-
-    <div class="d-grid gap-5 col-4 mx-auto">
+    <div class="d-grid gap-5 col-4 mx-auto py-5">
         <button type="submit" class="btn btn-primary" onclick="location.href='list'">
             {{ __('生徒一覧画面') }}
         </button>
         <button type="submit" class="btn btn-primary" onclick="location.href='notification'">
             {{ __('お知らせ投稿') }}
         </button>
-        <button type="submit" class="btn btn-primary" onclick="location.href='../teacher/chat'">
-            {{ __('生徒とチャット') }}
-        </button>
     </div>
-</div>
+@endsection

--- a/resources/views/teacher/list.blade.php
+++ b/resources/views/teacher/list.blade.php
@@ -1,6 +1,6 @@
 <!-- 5-1.生徒一覧画面 -->
 
-@extends('layouts.app')
+@extends('layouts.teacher')
 
 @section('content')
 
@@ -32,7 +32,7 @@
             <td>{{ $user->birthday }}</td>
             <td>{{ $user->email }}</td>
             <td style="text-align: center;"><a href="{{ url('/teacher/report') }}/{{ $user->id }}">{{ '体調確認画面へ' }}</a></td>  <!--urlの/2は生徒idが入るようにする-->
-            <td style="text-align: center;"><a href="{{ url('/teacher/chat') }}">{{ 'チャット画面へ' }}</a></td>
+            <td style="text-align: center;"><a href="{{ url('/teacher/chat') }}/{{ $user->id }}">{{ 'チャット画面へ' }}</a></td>
             <td style="text-align: center;"><button type="submit" class="btn btn-danger">{{ __('アカウント削除') }}</button></td>
         </tr>
         @endforeach

--- a/resources/views/teacher/noticehistory.blade.php
+++ b/resources/views/teacher/noticehistory.blade.php
@@ -1,31 +1,11 @@
 <!-- 7-2.お知らせ文編集／削除選択画面 -->
 
-@extends('layouts.app')
+@extends('layouts.teacher')
 
 @section('content')
 <form method="POST" action="{{ url('/teacher/noticehistory') }}">
     @csrf
-<div id="app">
-        <nav class="navbar navbar-expand-md navbar-light bg-white shadow-sm">
-            <div class="container">
-                <a class="navbar-brand" href="{{ url('/teacher/home') }}">
-                    {{ __('東京小学校　体調管理システム') }}
-                </a>
-                <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="{{ __('Toggle navigation') }}">
-                    <span class="navbar-toggler-icon"></span>
-                </button>
-
-                <div class="collapse navbar-collapse" id="navbarSupportedContent">
-
-            </div>
-        </nav>
-
-        <main class="py-4">
-            @yield('content')
-        </main>
-    </div>
-
-    <div class="gap-5 col-4 mx-3">
+    <div class="gap-5 col-4 mx-3 py-4">
         <button type="submit" class="btn btn-primary">
             <a href="{{ url('/teacher/home') }}"></a>{{ __('ホーム画面へ戻る') }}
         </button>
@@ -50,5 +30,4 @@
             <td style="text-align: center;"><button type="submit" class="btn btn-danger">削除する</button></td>
         </tr>
     </table>
-
-</div>
+@endsection

--- a/resources/views/teacher/report.blade.php
+++ b/resources/views/teacher/report.blade.php
@@ -1,31 +1,11 @@
 <!-- 5-2.生徒体調確認画面 -->
 
-@extends('layouts.app')
+@extends('layouts.teacher')
 
 @section('content')
 <form method="POST" action="{{ url('/teacher/report') }}">
     @csrf
-<div id="app">
-        <nav class="navbar navbar-expand-md navbar-light bg-white shadow-sm">
-            <div class="container">
-                <a class="navbar-brand" href="{{ url('/teacher/home') }}">
-                    {{ __('東京小学校　体調管理システム') }}
-                </a>
-                <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="{{ __('Toggle navigation') }}">
-                    <span class="navbar-toggler-icon"></span>
-                </button>
-
-                <div class="collapse navbar-collapse" id="navbarSupportedContent">
-
-            </div>
-        </nav>
-
-        <main class="py-4">
-            @yield('content')
-        </main>
-    </div>
-
-    <div class="gap-5 col-4 mx-3">
+    <div class="gap-5 col-4 mx-3 py-4">
         <a href="/teacher/home" class="btn btn-primary">
             {{ __('ホーム画面へ戻る') }}
         </a>

--- a/routes/web.php
+++ b/routes/web.php
@@ -84,20 +84,30 @@ Route::get('/student/list', function() {
 }); // 2022/5/28 下村追記 先生一覧画面用
 
 
+Route::get('/student/newslist', function() {
+    return view ('student/newslist');
+}); 
+
+Route::get('/student/manage', function() {
+    return view ('student/manage');
+}); 
+
 // チャット画面
 // Route::get('chat', [App\Http\Controllers\MessageController::class, 'chat']);
 // 2022/5/16 住吉Route変更
 // 2022/5/28 下村"先生用・生徒用のチャット画面を作成したので、ルーティング変更となります"
 
+// Route::get('/student/chat/{tid}/{id}', [App\Http\Controllers\HomeController::class, 'studentChat']);
 
 Route::get('/student/chat', function() {
     return view ('student/chat');
-}); // 2022/5/28 下村追記 生徒用チャット画面用
+});
+Route::get('/student/chat', [App\Http\Controllers\MessageController::class,'s_chat'])->name('message.chat');
 
 Route::get('/teacher/chat', function() {
     return view ('teacher/chat');
 }); // 2022/5/28 下村追記 先生用チャット画面用
-
+Route::get('/teacher/chat', [App\Http\Controllers\MessageController::class,'t_chat'])->name('message.chat');
 
 // Route::get('/student/edit', function () {
 //     return view('student/edit');


### PR DESCRIPTION
・チャット画面について
　⇒先生用(/teacher/chat)と生徒用(/student/chat)を追加しました。
　⇒DBへ登録できるようになってます。
　⇒投稿メッセージが空の場合、アラートが出る仕様にし、空の場合では投稿できないようになっています。
　⇒投稿日時もリアルタイムで表示できるようになっています。
　※投稿者の名前を引っ張ってこれるようにはなっていません。
　※過去投稿したメッセージを再度表示できるようにはなっていません。
　※chat_room_idとlogin_user_idが紐づいていない。(1つのチャット部屋に対し、他の生徒もURLを変えるだけで見れてしまう仕様のままです。

・先生用画面、生徒用画面の中には、同じレイアウト(画面構造)を使う部分もあるので、先生用のlayouts、生徒用のlayoutsを作成し共通できる部分については継承できるようにしました。